### PR TITLE
Simplified multi get operations

### DIFF
--- a/src/Couchbase.Reactive/BucketExtensions.cs
+++ b/src/Couchbase.Reactive/BucketExtensions.cs
@@ -26,29 +26,10 @@ namespace Couchbase.Reactive
                 throw new ArgumentNullException("bucket");
             }
 
-            return bucket.GetObservable<T>(keys, new ParallelOptions()
-            {
-                CancellationToken = CancellationToken.None,
-                MaxDegreeOfParallelism = bucket.Configuration.PoolConfiguration.MaxSize,
-                TaskScheduler = TaskScheduler.Current
-            });
-        }
-
-        public static IObservable<KeyValuePair<string, IOperationResult<T>>> GetObservable<T>(this IBucket bucket, IList<string> keys, ParallelOptions options)
-        {
-            if (bucket == null)
-            {
-                throw new ArgumentNullException("bucket");
-            }
-            if (options == null)
-            {
-                throw new ArgumentNullException("options");
-            }
-
             Func<string, KeyValuePair<string, IOperationResult<T>>> getFunction =
                 key => new KeyValuePair<string, IOperationResult<T>>(key, bucket.Get<T>(key));
 
-            return new MultiGetObservable<string, KeyValuePair<string, IOperationResult<T>>>(keys, getFunction, options);
+            return new MultiGetObservable<string, KeyValuePair<string, IOperationResult<T>>>(keys, getFunction);
         }
 
         public static IObservable<IOperationResult<T>> GetAndTouchObservable<T>(this IBucket bucket, string key, TimeSpan expiration)
@@ -73,29 +54,10 @@ namespace Couchbase.Reactive
                 throw new ArgumentNullException("bucket");
             }
 
-            return bucket.GetDocumentObservable<T>(ids, new ParallelOptions()
-            {
-                CancellationToken = CancellationToken.None,
-                MaxDegreeOfParallelism = bucket.Configuration.PoolConfiguration.MaxSize,
-                TaskScheduler = TaskScheduler.Current
-            });
-        }
-
-        public static IObservable<KeyValuePair<string, IDocumentResult<T>>> GetDocumentObservable<T>(this IBucket bucket, IList<string> ids, ParallelOptions options)
-        {
-            if (bucket == null)
-            {
-                throw new ArgumentNullException("bucket");
-            }
-            if (options == null)
-            {
-                throw new ArgumentNullException("options");
-            }
-
             Func<string, KeyValuePair<string, IDocumentResult<T>>> getFunction =
                 key => new KeyValuePair<string, IDocumentResult<T>>(key, bucket.GetDocument<T>(key));
 
-            return new MultiGetObservable<string, KeyValuePair<string, IDocumentResult<T>>>(ids, getFunction, options);
+            return new MultiGetObservable<string, KeyValuePair<string, IDocumentResult<T>>>(ids, getFunction);
         }
 
         public static IObservable<ViewRow<T>> QueryObservable<T>(this IBucket bucket, IViewQueryable query)


### PR DESCRIPTION
## Motivation

Current multi get operations are not as efficient as possible.  Because
the current SDK is primarily processor constrained on multi get
operations, it's best to simply use a simple Parallel.ForEach
implementation.

Additionally, the use of ParallelOptions as a parameter in the API makes
assumptions about how they will be implemented internally which probably
won't make sense in the future.  Once the Async SDK functionality of the
core SDK is made more efficient, the implementation may change to running
multiple async tasks instead of using Parallel.ForEach.

Finally, providing CancellationToken in ParallelOptions isn't consistent
with Rx methodology.  Cancellation in Rx is handled by calling Dispose on
IObserver returned by the subscription.
## Modifications

Eliminated the multi get overloads that accept ParallelOptions parameters.

Changed multi get implementation to work via Parallel.ForEach, which
automatically optimizes the process based on processor cores available.
Used a CancellationTokenSource so that the parallel process can be
cancelled early when Dispose is called.
## Results

Processing should be more efficiently parallelized.  In my test
environment, I experimented with tests getting 100,000 documents.  My best
attempts at Async task based multi gets were approximately 12 seconds.
This approach completes in approximately 7 seconds.

Additionally, the API is not as restrictive for future changes to back end
implementation because it doesn't assume we are using Parallel.ForEach by
having ParallelOptions as a parameter.

All tests are still passing.
