### PR TITLE
Improve error handling behaviors

### DIFF
--- a/src/Couchbase.Reactive.IntegrationTests/BucketExtensionsTests.cs
+++ b/src/Couchbase.Reactive.IntegrationTests/BucketExtensionsTests.cs
@@ -15,78 +15,399 @@ namespace Couchbase.Reactive.IntegrationTests
     [TestFixture]
     public class BucketExtensionsTests
     {
+
+        #region GetObservable
+
         [Test]
-        public void GetObject()
+        public void GetObservable_SingleDocument_KeyExists_GetsDocument()
         {
             using (var cluster = new Cluster(TestConfiguration.GetConfiguration("default")))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
-                    var observable = bucket.GetObservable<Beer>("21st_amendment_brewery_cafe-21a_ipa");
+                    const string key = "beer-test";
 
-                    observable.ForEachAsync(p => Console.WriteLine(p.Value.Name)).Wait();
-                }
-            }
-        }
-
-        [Test]
-        public void GetDocument()
-        {
-            using (var cluster = new Cluster(TestConfiguration.GetConfiguration("default")))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var observable = bucket.GetDocumentObservable<Beer>("21st_amendment_brewery_cafe-21a_ipa");
-
-                    observable.ForEachAsync(p => Console.WriteLine(p.Document.Content.Name)).Wait();
-                }
-            }
-        }
-
-        [Test]
-        public void MultiGetObject()
-        {
-            using (var cluster = new Cluster(TestConfiguration.GetConfiguration("default")))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var keys = new[]
+                    var testDocument = new Beer()
                     {
-                        "21st_amendment_brewery_cafe-21a_ipa",
-                        "21st_amendment_brewery_cafe-563_stout",
-                        "21st_amendment_brewery_cafe-amendment_pale_ale"
+                        Type = "beer",
+                        Name = "test"
                     };
 
-                    var observable = bucket.GetObservable<Beer>(keys);
+                    try
+                    {
+                        // Create the document for the test
+                        bucket.Upsert(new Document<Beer>
+                        {
+                            Id = key,
+                            Content = testDocument
+                        });
 
-                    observable.ForEachAsync(p => Console.WriteLine("{0} - {1}", p.Key, p.Value.Value.Name)).Wait();
+                        var observable = bucket.GetObservable<Beer>(key);
+
+                        var document = observable.ToEnumerable().Single();
+
+                        Assert.AreEqual(key, document.Key);
+                        Assert.AreEqual(testDocument.Name, document.Value.Name);
+                    }
+                    finally
+                    {
+                        // Cleanup
+                        bucket.Remove(key);
+                    }
                 }
             }
         }
 
         [Test]
-        public void MultiGetDocument()
+        public void GetObservable_SingleDocument_KeyDoesNotExist_NoResult()
         {
             using (var cluster = new Cluster(TestConfiguration.GetConfiguration("default")))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
-                    var keys = new[]
-                    {
-                        "21st_amendment_brewery_cafe-21a_ipa",
-                        "21st_amendment_brewery_cafe-563_stout",
-                        "21st_amendment_brewery_cafe-amendment_pale_ale"
-                    };
+                    const string key = "beer-test";
 
-                    var observable = bucket.GetDocumentObservable<Beer>(keys);
+                    // Ensure the key doesn't exist first
+                    bucket.Remove(key);
 
-                    observable.ForEachAsync(p => Console.WriteLine("{0} - {1}", p.Key, p.Value.Document.Content.Name)).Wait();
+                    var observable = bucket.GetObservable<Beer>(key);
+
+                    Assert.False(observable.ToEnumerable().Any());
                 }
             }
         }
 
         [Test]
-        public void QueryView()
+        public void GetObservable_MultiDocument_GetsDocuments()
+        {
+            using (var cluster = new Cluster(TestConfiguration.GetConfiguration("default")))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var testDocuments = new List<Document<Beer>>()
+                    {
+                        new Document<Beer>()
+                        {
+                            Id = "test-beer",
+                            Content = new Beer()
+                            {
+                                Type = "beer",
+                                Name = "test"
+                            }
+                        },
+                        new Document<Beer>()
+                        {
+                            Id = "test-beer2",
+                            Content = new Beer()
+                            {
+                                Type = "beer",
+                                Name = "test2"
+                            }
+                        },
+                        new Document<Beer>()
+                        {
+                            Id = "test-beer3",
+                            Content = new Beer()
+                            {
+                                Type = "beer",
+                                Name = "test3"
+                            }
+                        }
+                    };
+
+                    try
+                    {
+                        // Create the documents for the test
+                        testDocuments.ForEach(document =>
+                        {
+                            bucket.Upsert(document);
+                        });
+
+                        var observable = bucket.GetObservable<Beer>(testDocuments.Select(p => p.Id).ToArray());
+
+                        var documents = observable.ToEnumerable().OrderBy(p => p.Key).ToList();
+
+                        Assert.AreEqual(testDocuments.Count, documents.Count);
+
+                        var zipped = documents.Zip(testDocuments, (result, test) => new { Result = result, Test = test }).ToList();
+
+                        zipped.ForEach(zip =>
+                        {
+                            Assert.AreEqual(zip.Test.Id, zip.Result.Key);
+                            Assert.AreEqual(zip.Test.Content.Name, zip.Result.Value.Name);
+                        });
+                    }
+                    finally
+                    {
+                        // Cleanup
+                        bucket.Remove(testDocuments.Select(p => p.Id).ToList());
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void GetObservable_MultiDocument_SkipsMissingKeys()
+        {
+            using (var cluster = new Cluster(TestConfiguration.GetConfiguration("default")))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var testDocuments = new List<Document<Beer>>()
+                    {
+                        new Document<Beer>()
+                        {
+                            Id = "test-beer",
+                            Content = new Beer()
+                            {
+                                Type = "beer",
+                                Name = "test"
+                            }
+                        },
+                        new Document<Beer>()
+                        {
+                            Id = "test-beer2",
+                            Content = new Beer()
+                            {
+                                Type = "beer",
+                                Name = "test2"
+                            }
+                        },
+                        new Document<Beer>()
+                        {
+                            Id = "test-beer3",
+                            Content = new Beer()
+                            {
+                                Type = "beer",
+                                Name = "test3"
+                            }
+                        }
+                    };
+
+                    try
+                    {
+                        // Create the documents for the test
+                        testDocuments.Take(2).ToList().ForEach(document =>
+                        {
+                            bucket.Upsert(document);
+                        });
+
+                        bucket.Remove(testDocuments.Skip(2).Select(p => p.Id).ToList());
+
+                        var observable = bucket.GetObservable<Beer>(testDocuments.Select(p => p.Id).ToArray());
+
+                        var documents = observable.ToEnumerable().ToList();
+
+                        Assert.AreEqual(2, documents.Count);
+                    }
+                    finally
+                    {
+                        // Cleanup
+                        bucket.Remove(testDocuments.Select(p => p.Id).ToList());
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region GetDocumentObservable
+
+        [Test]
+        public void GetDocumentObservable_SingleDocument_KeyExists_GetsDocument()
+        {
+            using (var cluster = new Cluster(TestConfiguration.GetConfiguration("default")))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var testDocument = new Document<Beer>()
+                    {
+                        Id = "beer-test",
+                        Content = new Beer()
+                        {
+                            Type = "beer",
+                            Name = "test"
+                        }
+                    };
+
+                    try
+                    {
+                        // Create the document for the test
+                        bucket.Upsert(testDocument);
+
+                        var observable = bucket.GetDocumentObservable<Beer>(testDocument.Id);
+
+                        var document = observable.ToEnumerable().Single();
+
+                        Assert.AreEqual(testDocument.Id, document.Id);
+                        Assert.AreEqual(testDocument.Content.Name, document.Content.Name);
+                    }
+                    finally
+                    {
+                        // Cleanup
+                        bucket.Remove(testDocument.Id);
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void GetDocumentObservable_SingleDocument_KeyDoesNotExist_NoResult()
+        {
+            using (var cluster = new Cluster(TestConfiguration.GetConfiguration("default")))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    const string key = "beer-test";
+
+                    // Ensure the key doesn't exist first
+                    bucket.Remove(key);
+
+                    var observable = bucket.GetDocumentObservable<Beer>(key);
+
+                    Assert.False(observable.ToEnumerable().Any());
+                }
+            }
+        }
+
+        [Test]
+        public void GetDocumentObservable_MultiDocument_GetsDocuments()
+        {
+            using (var cluster = new Cluster(TestConfiguration.GetConfiguration("default")))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var testDocuments = new List<Document<Beer>>()
+                    {
+                        new Document<Beer>()
+                        {
+                            Id = "test-beer",
+                            Content = new Beer()
+                            {
+                                Type = "beer",
+                                Name = "test"
+                            }
+                        },
+                        new Document<Beer>()
+                        {
+                            Id = "test-beer2",
+                            Content = new Beer()
+                            {
+                                Type = "beer",
+                                Name = "test2"
+                            }
+                        },
+                        new Document<Beer>()
+                        {
+                            Id = "test-beer3",
+                            Content = new Beer()
+                            {
+                                Type = "beer",
+                                Name = "test3"
+                            }
+                        }
+                    };
+
+                    try
+                    {
+                        // Create the documents for the test
+                        testDocuments.ForEach(document =>
+                        {
+                            bucket.Upsert(document);
+                        });
+
+                        var observable = bucket.GetDocumentObservable<Beer>(testDocuments.Select(p => p.Id).ToArray());
+
+                        var documents = observable.ToEnumerable().OrderBy(p => p.Id).ToList();
+
+                        Assert.AreEqual(testDocuments.Count, documents.Count);
+
+                        var zipped = documents.Zip(testDocuments, (result, test) => new {Result = result, Test = test}).ToList();
+
+                        zipped.ForEach(zip =>
+                        {
+                            Assert.AreEqual(zip.Test.Id, zip.Result.Id);
+                            Assert.AreEqual(zip.Test.Content.Name, zip.Result.Content.Name);
+                        });
+                    }
+                    finally
+                    {
+                        // Cleanup
+                        bucket.Remove(testDocuments.Select(p => p.Id).ToList());
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void GetDocumentObservable_MultiDocument_SkipsMissingKeys()
+        {
+            using (var cluster = new Cluster(TestConfiguration.GetConfiguration("default")))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var testDocuments = new List<Document<Beer>>()
+                    {
+                        new Document<Beer>()
+                        {
+                            Id = "test-beer",
+                            Content = new Beer()
+                            {
+                                Type = "beer",
+                                Name = "test"
+                            }
+                        },
+                        new Document<Beer>()
+                        {
+                            Id = "test-beer2",
+                            Content = new Beer()
+                            {
+                                Type = "beer",
+                                Name = "test2"
+                            }
+                        },
+                        new Document<Beer>()
+                        {
+                            Id = "test-beer3",
+                            Content = new Beer()
+                            {
+                                Type = "beer",
+                                Name = "test3"
+                            }
+                        }
+                    };
+
+                    try
+                    {
+                        // Create the documents for the test
+                        testDocuments.Take(2).ToList().ForEach(document =>
+                        {
+                            bucket.Upsert(document);
+                        });
+
+                        bucket.Remove(testDocuments.Skip(2).Select(p => p.Id).ToList());
+
+                        var observable = bucket.GetDocumentObservable<Beer>(testDocuments.Select(p => p.Id).ToArray());
+
+                        var documents = observable.ToEnumerable().ToList();
+
+                        Assert.AreEqual(2, documents.Count);
+                    }
+                    finally
+                    {
+                        // Cleanup
+                        bucket.Remove(testDocuments.Select(p => p.Id).ToList());
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region QueryObservable
+
+        [Test]
+        public void QueryObservable_View()
         {
             using (var cluster = new Cluster(TestConfiguration.GetConfiguration("default")))
             {
@@ -110,7 +431,7 @@ namespace Couchbase.Reactive.IntegrationTests
         }
 
         [Test]
-        public void QueryView_ExpectError()
+        public void QueryObservable_View_ExpectError()
         {
             using (var cluster = new Cluster(TestConfiguration.GetConfiguration("default")))
             {
@@ -162,7 +483,7 @@ namespace Couchbase.Reactive.IntegrationTests
         }
 
         [Test]
-        public void QueryN1Ql()
+        public void QueryObservable_N1Ql()
         {
             using (var cluster = new Cluster(TestConfiguration.GetConfiguration("default")))
             {
@@ -183,14 +504,12 @@ namespace Couchbase.Reactive.IntegrationTests
         }
 
         [Test]
-        public void QueryN1Ql_ExpectError()
+        public void QueryObservable_N1Ql_ExpectError()
         {
             using (var cluster = new Cluster(TestConfiguration.GetConfiguration("default")))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
-                    var query = bucket.CreateQuery("beer", "brewery_beers_fake_view").Limit(10);
-
                     var observable = bucket.QueryObservable<Beer>("SELECT `beer-sample`.* FROM `beer - sample` WHERE type = 'beer' LIMIT 10 THIS IS BAD SYNTAX");
 
                     var lockObj = new object();
@@ -232,5 +551,7 @@ namespace Couchbase.Reactive.IntegrationTests
                 }
             }
         }
+
+        #endregion
     }
 }

--- a/src/Couchbase.Reactive.UnitTests/BucketExtensionTests.cs
+++ b/src/Couchbase.Reactive.UnitTests/BucketExtensionTests.cs
@@ -1,0 +1,841 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Core;
+using Couchbase.IO;
+using Couchbase.N1QL;
+using Couchbase.Reactive.UnitTests.Documents;
+using Couchbase.Reactive.UnitTests.Utils;
+using Couchbase.Views;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.Reactive.UnitTests
+{
+    [TestFixture]
+    public class BucketExtensionTests : TestBase
+    {
+        #region GetObservable
+
+        [Test]
+        public void GetObservable_SingleDocument_OperationThrowsException_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetAsync<Beer>(It.IsAny<string>())).Throws(new ObjectDisposedException("test"));
+
+            var observer = new AssertThrowsObserver<KeyValuePair<string, Beer>>();
+
+            // Act
+
+            bucket.Object.GetObservable<Beer>("key").Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<ObjectDisposedException>();
+            Assert.AreEqual("test", ex.ObjectName);
+        }
+
+        [Test]
+        public void GetObservable_SingleDocument_OperationReturnsException_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IOperationResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.Status).Returns(ResponseStatus.InternalError);
+            operationResult.Setup(m => m.Message).Returns("error message");
+            operationResult.Setup(m => m.Exception).Returns(new ApplicationException("exception message"));
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetAsync<Beer>(It.IsAny<string>())).Returns(Task.FromResult(operationResult.Object));
+
+            var observer = new AssertThrowsObserver<KeyValuePair<string, Beer>>();
+
+            // Act
+
+            bucket.Object.GetObservable<Beer>("key").Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseGetException>();
+            Assert.True(ex.Message.Contains(operationResult.Object.Message));
+            Assert.AreEqual(operationResult.Object.Status, ex.Status);
+            Assert.AreEqual(operationResult.Object.Exception, ex.InnerException);
+        }
+
+        [Test]
+        public void GetObservable_SingleDocument_OperationReturnsError_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IOperationResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.Status).Returns(ResponseStatus.AuthenticationError);
+            operationResult.Setup(m => m.Message).Returns("error message");
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetAsync<Beer>(It.IsAny<string>())).Returns(Task.FromResult(operationResult.Object));
+
+            var observer = new AssertThrowsObserver<KeyValuePair<string, Beer>>();
+
+            // Act
+
+            bucket.Object.GetObservable<Beer>("key").Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseGetException>();
+            Assert.True(ex.Message.Contains(operationResult.Object.Message));
+            Assert.AreEqual(operationResult.Object.Status, ex.Status);
+        }
+
+        [Test]
+        public void GetObservable_SingleDocument_OperationReturnsKeyNotFound_ReturnsEmptyResult()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IOperationResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.Status).Returns(ResponseStatus.KeyNotFound);
+            operationResult.Setup(m => m.Message).Returns("error message");
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetAsync<Beer>(It.IsAny<string>())).Returns(Task.FromResult(operationResult.Object));
+
+            // Act
+
+            var results = bucket.Object.GetObservable<Beer>("key").ToEnumerable();
+
+            // Assert
+
+            Assert.IsEmpty(results);
+        }
+
+        [Test]
+        public void GetObservable_MultiDocument_OperationThrowsException_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var keys = new[] { "key1", "key2", "key3" };
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.Get<Beer>(It.IsAny<string>())).Throws(new ObjectDisposedException("test"));
+
+            var observer = new AssertThrowsObserver<KeyValuePair<string, Beer>>();
+
+            // Act
+
+            bucket.Object.GetObservable<Beer>(keys).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<ObjectDisposedException>();
+            Assert.AreEqual("test", ex.ObjectName);
+        }
+
+        [Test]
+        public void GetObservable_MultiDocument_OperationReturnsException_CallsOnErrorWithException()
+        {
+            var keys = new[] { "key1", "key2", "key3" };
+
+            // Arrange
+
+            var successOperationResult = new Mock<IOperationResult<Beer>>();
+            successOperationResult.Setup(m => m.Success).Returns(true);
+            successOperationResult.Setup(m => m.Status).Returns(ResponseStatus.Success);
+            successOperationResult.Setup(m => m.Value).Returns(new Beer { Name = "Beer" });
+
+            var errorOperationResult = new Mock<IOperationResult<Beer>>();
+            errorOperationResult.Setup(m => m.Success).Returns(false);
+            errorOperationResult.Setup(m => m.Status).Returns(ResponseStatus.InternalError);
+            errorOperationResult.Setup(m => m.Message).Returns("error message");
+            errorOperationResult.Setup(m => m.Exception).Returns(new ApplicationException("exception message"));
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.Get<Beer>(keys[0])).Returns(successOperationResult.Object);
+            bucket.Setup(m => m.Get<Beer>(keys[1])).Returns(successOperationResult.Object);
+            bucket.Setup(m => m.Get<Beer>(keys[2])).Returns(errorOperationResult.Object);
+
+            var observer = new AssertThrowsObserver<KeyValuePair<string, Beer>>();
+
+            // Act
+
+            bucket.Object.GetObservable<Beer>(keys).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseGetException>();
+            Assert.True(ex.Message.Contains(errorOperationResult.Object.Message));
+            Assert.AreEqual(errorOperationResult.Object.Status, ex.Status);
+            Assert.AreEqual(errorOperationResult.Object.Exception, ex.InnerException);
+        }
+
+        [Test]
+        public void GetObservable_MultiDocument_OperationReturnsError_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var keys = new[] { "key1", "key2", "key3" };
+
+            var successOperationResult = new Mock<IOperationResult<Beer>>();
+            successOperationResult.Setup(m => m.Success).Returns(true);
+            successOperationResult.Setup(m => m.Status).Returns(ResponseStatus.Success);
+            successOperationResult.Setup(m => m.Value).Returns(new Beer { Name = "Beer" });
+
+            var errorOperationResult = new Mock<IOperationResult<Beer>>();
+            errorOperationResult.Setup(m => m.Success).Returns(false);
+            errorOperationResult.Setup(m => m.Status).Returns(ResponseStatus.AuthenticationError);
+            errorOperationResult.Setup(m => m.Message).Returns("error message");
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.Get<Beer>(keys[0])).Returns(successOperationResult.Object);
+            bucket.Setup(m => m.Get<Beer>(keys[1])).Returns(successOperationResult.Object);
+            bucket.Setup(m => m.Get<Beer>(keys[2])).Returns(errorOperationResult.Object);
+
+            var observer = new AssertThrowsObserver<KeyValuePair<string, Beer>>();
+
+            // Act
+
+            bucket.Object.GetObservable<Beer>(keys).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseGetException>();
+            Assert.True(ex.Message.Contains(errorOperationResult.Object.Message));
+            Assert.AreEqual(errorOperationResult.Object.Status, ex.Status);
+        }
+
+        [Test]
+        public void GetObservable_MultiDocument_OperationReturnsKeyNotFound_ReturnsEmptyResult()
+        {
+            // Arrange
+
+            var keys = new[] { "key1", "key2", "key3" };
+
+            var successOperationResult = new Mock<IOperationResult<Beer>>();
+            successOperationResult.Setup(m => m.Success).Returns(true);
+            successOperationResult.Setup(m => m.Status).Returns(ResponseStatus.Success);
+            successOperationResult.Setup(m => m.Value).Returns(new Beer { Name = "Beer" });
+
+            var notFoundOperationResult = new Mock<IOperationResult<Beer>>();
+            notFoundOperationResult.Setup(m => m.Success).Returns(false);
+            notFoundOperationResult.Setup(m => m.Status).Returns(ResponseStatus.KeyNotFound);
+            notFoundOperationResult.Setup(m => m.Message).Returns("error message");
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.Get<Beer>(keys[0])).Returns(successOperationResult.Object);
+            bucket.Setup(m => m.Get<Beer>(keys[1])).Returns(successOperationResult.Object);
+            bucket.Setup(m => m.Get<Beer>(keys[2])).Returns(notFoundOperationResult.Object);
+
+
+            // Act
+
+            var results = bucket.Object.GetObservable<Beer>(keys).ToEnumerable();
+
+            // Assert
+
+            Assert.AreEqual(2, results.Count());
+        }
+
+        #endregion
+
+        #region GetAndTouchObservable
+
+        [Test]
+        public void GetAndTouchObservable_OperationThrowsException_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetAndTouchAsync<Beer>(It.IsAny<string>(), It.IsAny<TimeSpan>()))
+                .Throws(new ObjectDisposedException("test"));
+
+            var observer = new AssertThrowsObserver<KeyValuePair<string, Beer>>();
+
+            // Act
+
+            bucket.Object.GetAndTouchObservable<Beer>("key", TimeSpan.Zero).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<ObjectDisposedException>();
+            Assert.AreEqual("test", ex.ObjectName);
+        }
+
+        [Test]
+        public void GetAndTouchObservable_OperationReturnsException_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IOperationResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.Status).Returns(ResponseStatus.InternalError);
+            operationResult.Setup(m => m.Message).Returns("error message");
+            operationResult.Setup(m => m.Exception).Returns(new ApplicationException("exception message"));
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetAndTouchAsync<Beer>(It.IsAny<string>(), It.IsAny<TimeSpan>()))
+                .Returns(Task.FromResult(operationResult.Object));
+
+            var observer = new AssertThrowsObserver<KeyValuePair<string, Beer>>();
+
+            // Act
+
+            bucket.Object.GetAndTouchObservable<Beer>("key", TimeSpan.Zero).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseGetException>();
+            Assert.True(ex.Message.Contains(operationResult.Object.Message));
+            Assert.AreEqual(operationResult.Object.Status, ex.Status);
+            Assert.AreEqual(operationResult.Object.Exception, ex.InnerException);
+        }
+
+        [Test]
+        public void GetAndTouchObservable_OperationReturnsError_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IOperationResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.Status).Returns(ResponseStatus.AuthenticationError);
+            operationResult.Setup(m => m.Message).Returns("error message");
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetAndTouchAsync<Beer>(It.IsAny<string>(), It.IsAny<TimeSpan>()))
+                .Returns(Task.FromResult(operationResult.Object));
+
+            var observer = new AssertThrowsObserver<KeyValuePair<string, Beer>>();
+
+            // Act
+
+            bucket.Object.GetAndTouchObservable<Beer>("key", TimeSpan.Zero).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseGetException>();
+            Assert.True(ex.Message.Contains(operationResult.Object.Message));
+            Assert.AreEqual(operationResult.Object.Status, ex.Status);
+        }
+
+        [Test]
+        public void GetAndTouchObservable_OperationReturnsKeyNotFound_ReturnsEmptyResult()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IOperationResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.Status).Returns(ResponseStatus.KeyNotFound);
+            operationResult.Setup(m => m.Message).Returns("error message");
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetAndTouchAsync<Beer>(It.IsAny<string>(), It.IsAny<TimeSpan>()))
+                .Returns(Task.FromResult(operationResult.Object));
+
+            // Act
+
+            var results = bucket.Object.GetAndTouchObservable<Beer>("key", TimeSpan.Zero).ToEnumerable();
+
+            // Assert
+
+            Assert.IsEmpty(results);
+        }
+
+        #endregion
+
+        #region GetDocumentObservable
+
+        [Test]
+        public void GetDocumentObservable_SingleDocument_OperationThrowsException_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetDocumentAsync<Beer>(It.IsAny<string>())).Throws(new ObjectDisposedException("test"));
+
+            var observer = new AssertThrowsObserver<IDocument<Beer>>();
+
+            // Act
+
+            bucket.Object.GetDocumentObservable<Beer>("key").Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<ObjectDisposedException>();
+            Assert.AreEqual("test", ex.ObjectName);
+        }
+
+        [Test]
+        public void GetDocumentObservable_SingleDocument_OperationReturnsException_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IDocumentResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.Status).Returns(ResponseStatus.InternalError);
+            operationResult.Setup(m => m.Message).Returns("error message");
+            operationResult.Setup(m => m.Exception).Returns(new ApplicationException("exception message"));
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetDocumentAsync<Beer>(It.IsAny<string>())).Returns(Task.FromResult(operationResult.Object));
+
+            var observer = new AssertThrowsObserver<IDocument<Beer>>();
+
+            // Act
+
+            bucket.Object.GetDocumentObservable<Beer>("key").Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseGetException>();
+            Assert.True(ex.Message.Contains(operationResult.Object.Message));
+            Assert.AreEqual(operationResult.Object.Status, ex.Status);
+            Assert.AreEqual(operationResult.Object.Exception, ex.InnerException);
+        }
+
+        [Test]
+        public void GetDocumentObservable_SingleDocument_OperationReturnsError_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IDocumentResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.Status).Returns(ResponseStatus.AuthenticationError);
+            operationResult.Setup(m => m.Message).Returns("error message");
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetDocumentAsync<Beer>(It.IsAny<string>())).Returns(Task.FromResult(operationResult.Object));
+
+            var observer = new AssertThrowsObserver<IDocument<Beer>>();
+
+            // Act
+
+            bucket.Object.GetDocumentObservable<Beer>("key").Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseGetException>();
+            Assert.True(ex.Message.Contains(operationResult.Object.Message));
+            Assert.AreEqual(operationResult.Object.Status, ex.Status);
+        }
+
+        [Test]
+        public void GetDocumentObservable_SingleDocument_OperationReturnsKeyNotFound_ReturnsEmptyResult()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IDocumentResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.Status).Returns(ResponseStatus.KeyNotFound);
+            operationResult.Setup(m => m.Message).Returns("error message");
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetDocumentAsync<Beer>(It.IsAny<string>())).Returns(Task.FromResult(operationResult.Object));
+
+            // Act
+
+            var results = bucket.Object.GetDocumentObservable<Beer>("key").ToEnumerable();
+
+            // Assert
+
+            Assert.IsEmpty(results);
+        }
+
+        [Test]
+        public void GetDocumentObservable_MultiDocument_OperationThrowsException_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var keys = new[] { "key1", "key2", "key3" };
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetDocument<Beer>(It.IsAny<string>())).Throws(new ObjectDisposedException("test"));
+
+            var observer = new AssertThrowsObserver<IDocument<Beer>>();
+
+            // Act
+
+            bucket.Object.GetDocumentObservable<Beer>(keys).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<ObjectDisposedException>();
+            Assert.AreEqual("test", ex.ObjectName);
+        }
+
+        [Test]
+        public void GetDocumentObservable_MultiDocument_OperationReturnsException_CallsOnErrorWithException()
+        {
+            var keys = new[] { "key1", "key2", "key3" };
+
+            // Arrange
+
+            var successOperationResult = new Mock<IDocumentResult<Beer>>();
+            successOperationResult.Setup(m => m.Success).Returns(true);
+            successOperationResult.Setup(m => m.Status).Returns(ResponseStatus.Success);
+            successOperationResult.Setup(m => m.Content).Returns(new Beer { Name = "Beer" });
+
+            var errorOperationResult = new Mock<IDocumentResult<Beer>>();
+            errorOperationResult.Setup(m => m.Success).Returns(false);
+            errorOperationResult.Setup(m => m.Status).Returns(ResponseStatus.InternalError);
+            errorOperationResult.Setup(m => m.Message).Returns("error message");
+            errorOperationResult.Setup(m => m.Exception).Returns(new ApplicationException("exception message"));
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetDocument<Beer>(keys[0])).Returns(successOperationResult.Object);
+            bucket.Setup(m => m.GetDocument<Beer>(keys[1])).Returns(successOperationResult.Object);
+            bucket.Setup(m => m.GetDocument<Beer>(keys[2])).Returns(errorOperationResult.Object);
+
+            var observer = new AssertThrowsObserver<IDocument<Beer>>();
+
+            // Act
+
+            bucket.Object.GetDocumentObservable<Beer>(keys).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseGetException>();
+            Assert.True(ex.Message.Contains(errorOperationResult.Object.Message));
+            Assert.AreEqual(errorOperationResult.Object.Status, ex.Status);
+            Assert.AreEqual(errorOperationResult.Object.Exception, ex.InnerException);
+        }
+
+        [Test]
+        public void GetDocumentObservable_MultiDocument_OperationReturnsError_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var keys = new[] { "key1", "key2", "key3" };
+
+            var successOperationResult = new Mock<IDocumentResult<Beer>>();
+            successOperationResult.Setup(m => m.Success).Returns(true);
+            successOperationResult.Setup(m => m.Status).Returns(ResponseStatus.Success);
+            successOperationResult.Setup(m => m.Content).Returns(new Beer { Name = "Beer" });
+
+            var errorOperationResult = new Mock<IDocumentResult<Beer>>();
+            errorOperationResult.Setup(m => m.Success).Returns(false);
+            errorOperationResult.Setup(m => m.Status).Returns(ResponseStatus.AuthenticationError);
+            errorOperationResult.Setup(m => m.Message).Returns("error message");
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetDocument<Beer>(keys[0])).Returns(successOperationResult.Object);
+            bucket.Setup(m => m.GetDocument<Beer>(keys[1])).Returns(successOperationResult.Object);
+            bucket.Setup(m => m.GetDocument<Beer>(keys[2])).Returns(errorOperationResult.Object);
+
+            var observer = new AssertThrowsObserver<IDocument<Beer>>();
+
+            // Act
+
+            bucket.Object.GetDocumentObservable<Beer>(keys).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseGetException>();
+            Assert.True(ex.Message.Contains(errorOperationResult.Object.Message));
+            Assert.AreEqual(errorOperationResult.Object.Status, ex.Status);
+        }
+
+        [Test]
+        public void GetDocumentObservable_MultiDocument_OperationReturnsKeyNotFound_ReturnsEmptyResult()
+        {
+            // Arrange
+
+            var keys = new[] { "key1", "key2", "key3" };
+
+            var successOperationResult = new Mock<IDocumentResult<Beer>>();
+            successOperationResult.Setup(m => m.Success).Returns(true);
+            successOperationResult.Setup(m => m.Status).Returns(ResponseStatus.Success);
+            successOperationResult.Setup(m => m.Content).Returns(new Beer { Name = "Beer" });
+
+            var notFoundOperationResult = new Mock<IDocumentResult<Beer>>();
+            notFoundOperationResult.Setup(m => m.Success).Returns(false);
+            notFoundOperationResult.Setup(m => m.Status).Returns(ResponseStatus.KeyNotFound);
+            notFoundOperationResult.Setup(m => m.Message).Returns("error message");
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetDocument<Beer>(keys[0])).Returns(successOperationResult.Object);
+            bucket.Setup(m => m.GetDocument<Beer>(keys[1])).Returns(successOperationResult.Object);
+            bucket.Setup(m => m.GetDocument<Beer>(keys[2])).Returns(notFoundOperationResult.Object);
+
+
+            // Act
+
+            var results = bucket.Object.GetDocumentObservable<Beer>(keys).ToEnumerable();
+
+            // Assert
+
+            Assert.AreEqual(2, results.Count());
+        }
+
+        #endregion
+
+        #region GetAndTouchDocumentObservable
+
+        [Test]
+        public void GetAndTouchDocumentObservable_OperationThrowsException_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetAndTouchDocumentAsync<Beer>(It.IsAny<string>(), It.IsAny<TimeSpan>()))
+                .Throws(new ObjectDisposedException("test"));
+
+            var observer = new AssertThrowsObserver<IDocument<Beer>>();
+
+            // Act
+
+            bucket.Object.GetAndTouchDocumentObservable<Beer>("key", TimeSpan.Zero).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<ObjectDisposedException>();
+            Assert.AreEqual("test", ex.ObjectName);
+        }
+
+        [Test]
+        public void GetAndTouchDocumentObservable_OperationReturnsException_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IDocumentResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.Status).Returns(ResponseStatus.InternalError);
+            operationResult.Setup(m => m.Message).Returns("error message");
+            operationResult.Setup(m => m.Exception).Returns(new ApplicationException("exception message"));
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetAndTouchDocumentAsync<Beer>(It.IsAny<string>(), It.IsAny<TimeSpan>()))
+                .Returns(Task.FromResult(operationResult.Object));
+
+            var observer = new AssertThrowsObserver<IDocument<Beer>>();
+
+            // Act
+
+            bucket.Object.GetAndTouchDocumentObservable<Beer>("key", TimeSpan.Zero).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseGetException>();
+            Assert.True(ex.Message.Contains(operationResult.Object.Message));
+            Assert.AreEqual(operationResult.Object.Status, ex.Status);
+            Assert.AreEqual(operationResult.Object.Exception, ex.InnerException);
+        }
+
+        [Test]
+        public void GetAndTouchDocumentObservable_OperationReturnsError_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IDocumentResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.Status).Returns(ResponseStatus.AuthenticationError);
+            operationResult.Setup(m => m.Message).Returns("error message");
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetAndTouchDocumentAsync<Beer>(It.IsAny<string>(), It.IsAny<TimeSpan>()))
+                .Returns(Task.FromResult(operationResult.Object));
+
+            var observer = new AssertThrowsObserver<IDocument<Beer>>();
+
+            // Act
+
+            bucket.Object.GetAndTouchDocumentObservable<Beer>("key", TimeSpan.Zero).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseGetException>();
+            Assert.True(ex.Message.Contains(operationResult.Object.Message));
+            Assert.AreEqual(operationResult.Object.Status, ex.Status);
+        }
+
+        [Test]
+        public void GetAndTouchDocumentObservable_OperationReturnsKeyNotFound_ReturnsEmptyResult()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IDocumentResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.Status).Returns(ResponseStatus.KeyNotFound);
+            operationResult.Setup(m => m.Message).Returns("error message");
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.GetAndTouchDocumentAsync<Beer>(It.IsAny<string>(), It.IsAny<TimeSpan>()))
+                .Returns(Task.FromResult(operationResult.Object));
+
+            // Act
+
+            var results = bucket.Object.GetAndTouchDocumentObservable<Beer>("key", TimeSpan.Zero).ToEnumerable();
+
+            // Assert
+
+            Assert.IsEmpty(results);
+        }
+
+        #endregion
+
+        #region QueryObservable
+
+        [Test]
+        public void QueryObservable_ViewQuery_OperationThrowsException_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.QueryAsync<Beer>(It.IsAny<IViewQueryable>()))
+                .Throws(new ObjectDisposedException("test"));
+
+            var observer = new AssertThrowsObserver<ViewRow<Beer>>();
+
+            // Act
+
+            bucket.Object.QueryObservable<Beer>(new ViewQuery()).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<ObjectDisposedException>();
+            Assert.AreEqual("test", ex.ObjectName);
+        }
+
+        [Test]
+        public void QueryObservable_ViewQuery_OperationReturnsException_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IViewResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.StatusCode).Returns(HttpStatusCode.InternalServerError);
+            operationResult.Setup(m => m.Error).Returns("error message");
+            operationResult.Setup(m => m.Exception).Returns(new ApplicationException("exception message"));
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.QueryAsync<Beer>(It.IsAny<IViewQueryable>()))
+                .Returns(Task.FromResult(operationResult.Object));
+
+            var observer = new AssertThrowsObserver<ViewRow<Beer>>();
+
+            // Act
+
+            bucket.Object.QueryObservable<Beer>(new ViewQuery()).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseViewQueryException>();
+            Assert.True(ex.Message.Contains(operationResult.Object.Error));
+            Assert.AreEqual(operationResult.Object.Error, ex.Error);
+            Assert.AreEqual(operationResult.Object.StatusCode, ex.StatusCode);
+            Assert.AreEqual(operationResult.Object.Exception, ex.InnerException);
+        }
+
+        [Test]
+        public void QueryObservable_ViewQuery_OperationReturnsError_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IViewResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.StatusCode).Returns(HttpStatusCode.InternalServerError);
+            operationResult.Setup(m => m.Error).Returns("error message");
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.QueryAsync<Beer>(It.IsAny<IViewQueryable>()))
+                .Returns(Task.FromResult(operationResult.Object));
+
+            var observer = new AssertThrowsObserver<ViewRow<Beer>>();
+
+            // Act
+
+            bucket.Object.QueryObservable<Beer>(new ViewQuery()).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseViewQueryException>();
+            Assert.True(ex.Message.Contains(operationResult.Object.Error));
+            Assert.AreEqual(operationResult.Object.Error, ex.Error);
+            Assert.AreEqual(operationResult.Object.StatusCode, ex.StatusCode);
+        }
+
+        [Test]
+        public void QueryObservable_QueryRequest_OperationThrowsException_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.QueryAsync<Beer>(It.IsAny<IQueryRequest>()))
+                .Throws(new ObjectDisposedException("test"));
+
+            var observer = new AssertThrowsObserver<Beer>();
+
+            // Act
+
+            bucket.Object.QueryObservable<Beer>(new QueryRequest()).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<ObjectDisposedException>();
+            Assert.AreEqual("test", ex.ObjectName);
+        }
+
+        [Test]
+        public void QueryObservable_QueryRequest_OperationReturnsException_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IQueryResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.Status).Returns(QueryStatus.Fatal);
+            operationResult.Setup(m => m.Exception).Returns(new ApplicationException("exception message"));
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.QueryAsync<Beer>(It.IsAny<IQueryRequest>()))
+                .Returns(Task.FromResult(operationResult.Object));
+
+            var observer = new AssertThrowsObserver<Beer>();
+
+            // Act
+
+            bucket.Object.QueryObservable<Beer>(new QueryRequest()).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseN1QlQueryException>();
+            Assert.True(ex.Message.Contains(operationResult.Object.Exception.Message));
+            Assert.AreEqual(operationResult.Object.Status, ex.Status);
+            Assert.AreEqual(operationResult.Object.Exception, ex.InnerException);
+        }
+
+        [Test]
+        public void QueryObservable_QueryRequest_OperationReturnsError_CallsOnErrorWithException()
+        {
+            // Arrange
+
+            var operationResult = new Mock<IQueryResult<Beer>>();
+            operationResult.Setup(m => m.Success).Returns(false);
+            operationResult.Setup(m => m.Status).Returns(QueryStatus.Errors);
+            operationResult.Setup(m => m.Errors).Returns(new List<Error> { new Error { Message = "error message" } });
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(m => m.QueryAsync<Beer>(It.IsAny<IQueryRequest>()))
+                .Returns(Task.FromResult(operationResult.Object));
+
+            var observer = new AssertThrowsObserver<Beer>();
+
+            // Act
+
+            bucket.Object.QueryObservable<Beer>(new QueryRequest()).Subscribe(observer);
+
+            // Assert
+
+            var ex = observer.Assert<CouchbaseN1QlQueryException>();
+            Assert.True(ex.Message.Contains(operationResult.Object.Errors.First().Message));
+            Assert.AreEqual(operationResult.Object.Status, ex.Status);
+        }
+
+        #endregion
+    }
+}

--- a/src/Couchbase.Reactive.UnitTests/Couchbase.Reactive.UnitTests.csproj
+++ b/src/Couchbase.Reactive.UnitTests/Couchbase.Reactive.UnitTests.csproj
@@ -4,18 +4,15 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{132AF7CC-9157-4D38-A7B6-9F49A67903FB}</ProjectGuid>
+    <ProjectGuid>{A7337740-FC0C-4B70-B27E-C3407E8B017A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Couchbase.Reactive</RootNamespace>
-    <AssemblyName>Couchbase.Reactive</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <RootNamespace>Couchbase.Reactive.UnitTests</RootNamespace>
+    <AssemblyName>Couchbase.Reactive.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -25,16 +22,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
@@ -49,12 +42,24 @@
       <HintPath>..\packages\CouchbaseNetClient.2.2.4\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Reactive.Testing, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Testing.2.2.5\lib\net45\Microsoft.Reactive.Testing.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
@@ -72,27 +77,29 @@
       <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Deployment" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="BucketExtensions.cs" />
-    <Compile Include="CouchbaseGetDocumentException.cs" />
-    <Compile Include="CouchbaseGetOperationException.cs" />
-    <Compile Include="CouchbaseN1QlQueryExceptionT.cs" />
-    <Compile Include="CouchbaseN1QlQueryException.cs" />
-    <Compile Include="CouchbaseGetException.cs" />
-    <Compile Include="CouchbaseReactiveException.cs" />
-    <Compile Include="CouchbaseViewQueryExceptionT.cs" />
-    <Compile Include="CouchbaseViewQueryException.cs" />
-    <Compile Include="MultiGetObservable.cs" />
+    <Compile Include="BucketExtensionTests.cs" />
+    <Compile Include="Documents\Beer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="N1QlQueryObservable.cs" />
-    <Compile Include="ViewQueryObservable.cs" />
+    <Compile Include="TestBase.cs" />
+    <Compile Include="Utils\AssertThrowsObserver.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="app.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Couchbase.Reactive\Couchbase.Reactive.csproj">
+      <Project>{132af7cc-9157-4d38-a7b6-9f49a67903fb}</Project>
+      <Name>Couchbase.Reactive</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Couchbase.Reactive.UnitTests/Documents/Beer.cs
+++ b/src/Couchbase.Reactive.UnitTests/Documents/Beer.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Couchbase.Reactive.UnitTests.Documents
+{
+    public class Beer
+    {
+        [JsonProperty("name")]
+        public virtual string Name { get; set; }
+
+        [JsonProperty("abv")]
+        public virtual decimal Abv { get; set; }
+
+        [JsonProperty("ibu")]
+        public virtual decimal Ibu { get; set; }
+
+        [JsonProperty("srm")]
+        public virtual decimal Srm { get; set; }
+
+        [JsonProperty("upc")]
+        public virtual decimal Upc { get; set; }
+
+        [JsonProperty("type")]
+        public virtual string Type { get; set; }
+
+        [JsonProperty("brewery_id")]
+        public virtual string BreweryId { get; set; }
+
+        [JsonProperty("description")]
+        public virtual string Description { get; set; }
+
+        [JsonProperty("style")]
+        public virtual string Style { get; set; }
+
+        [JsonProperty("category")]
+        public virtual string Category { get; set; }
+
+        [JsonProperty("updated")]
+        public virtual DateTime Updated { get; set; }
+    }
+}

--- a/src/Couchbase.Reactive.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/Couchbase.Reactive.UnitTests/Properties/AssemblyInfo.cs
@@ -2,38 +2,35 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
+// General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("CouchbaseReactive")]
+[assembly: AssemblyTitle("Couchbase.Reactive.UnitTests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("CouchbaseReactive")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyProduct("Couchbase.Reactive.UnitTests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("132af7cc-9157-4d38-a7b6-9f49a67903fb")]
+[assembly: Guid("a7337740-fc0c-4b70-b27e-c3407e8b017a")]
 
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version
+//      Minor Version 
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers
+// You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-
-[assembly: InternalsVisibleTo("Couchbase.Reactive.IntegrationTests")]
-[assembly: InternalsVisibleTo("Couchbase.Reactive.UnitTests")]

--- a/src/Couchbase.Reactive.UnitTests/TestBase.cs
+++ b/src/Couchbase.Reactive.UnitTests/TestBase.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Core;
+
+namespace Couchbase.Reactive.UnitTests
+{
+    public abstract class TestBase
+    {
+    }
+}

--- a/src/Couchbase.Reactive.UnitTests/Utils/AssertThrowsObserver.cs
+++ b/src/Couchbase.Reactive.UnitTests/Utils/AssertThrowsObserver.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Couchbase.Reactive.UnitTests.Utils
+{
+    class AssertThrowsObserver<TElement> : IObserver<TElement>
+    {
+        private readonly ManualResetEvent _event = new ManualResetEvent(false);
+        private Exception _error = null;
+
+        public void OnNext(TElement value)
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+            _error = error;
+            _event.Set();
+        }
+
+        public void OnCompleted()
+        {
+            _event.Set();
+        }
+
+        public TException Assert<TException>() where TException : Exception
+        {
+            return Assert< TException>(Timeout.InfiniteTimeSpan);
+        }
+
+        public TException Assert<TException>(TimeSpan timeout) where TException : Exception
+        {
+            var fired = _event.WaitOne(timeout, true);
+
+            if (!fired)
+            {
+                throw new AssertionException("AssertThrowsException timed out waiting for a result.");
+            }
+
+            if (_error == null)
+            {
+                throw new AssertionException(
+                    string.Format("AssertThrowsException expected {0}, but did not receive an exception.", typeof(TException).Name));
+            }
+
+            var typedError = _error as TException;
+            if (typedError == null)
+            {
+                throw new AssertionException(
+                    string.Format("AssertThrowsException expected {0}, but received {1}.", typeof(TException).Name, _error.GetType().Name), _error);
+            }
+
+            return typedError;
+        }
+    }
+}

--- a/src/Couchbase.Reactive.UnitTests/app.config
+++ b/src/Couchbase.Reactive.UnitTests/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.1.0" newVersion="3.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.1.0" newVersion="3.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Couchbase.Reactive.UnitTests/packages.config
+++ b/src/Couchbase.Reactive.UnitTests/packages.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Common.Logging" version="3.3.1" targetFramework="net452" />
+  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net452" />
+  <package id="CouchbaseNetClient" version="2.2.4" targetFramework="net452" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
+  <package id="NUnit" version="3.0.1" targetFramework="net452" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Testing" version="2.2.5" targetFramework="net452" />
+</packages>

--- a/src/Couchbase.Reactive/CouchbaseGetDocumentException.cs
+++ b/src/Couchbase.Reactive/CouchbaseGetDocumentException.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Reactive
+{
+    /// <summary>
+    /// Exception wrapping an error returned by a Get request via the Reactive engine.
+    /// </summary>
+    class CouchbaseGetDocumentException<T> : CouchbaseGetException
+    {
+        private readonly IDocumentResult<T> _documentResult;
+
+        /// <summary>
+        /// <see cref="IDocumentResult{T}"/> returned by the Couchbase SDK.
+        /// </summary>
+        public IDocumentResult<T> DocumentResult
+        {
+            get { return _documentResult; }
+        }
+
+        internal CouchbaseGetDocumentException(IDocumentResult<T> documentResult)
+            : base(documentResult.Status, "Couchbase Get operation returned an error: " + documentResult.Message, documentResult.Exception)
+        {
+            if (documentResult == null)
+            {
+                throw new ArgumentNullException("documentResult");
+            }
+
+            _documentResult = documentResult;
+        }
+    }
+}

--- a/src/Couchbase.Reactive/CouchbaseGetException.cs
+++ b/src/Couchbase.Reactive/CouchbaseGetException.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.IO;
+
+namespace Couchbase.Reactive
+{
+    /// <summary>
+    /// Base class for exceptions wrapping errors returned by Get requests via the Reactive engine.
+    /// </summary>
+    public abstract class CouchbaseGetException : CouchbaseReactiveException
+    {
+        private readonly ResponseStatus _status;
+
+        /// <summary>
+        /// The response status returned by the server when fulfilling the request.
+        /// </summary>
+        public ResponseStatus Status
+        {
+            get { return _status; }
+        }
+
+        internal CouchbaseGetException(ResponseStatus status, string message)
+            : base(message)
+        {
+            _status = status;
+        }
+
+        internal CouchbaseGetException(ResponseStatus status, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            _status = status;
+        }
+    }
+}

--- a/src/Couchbase.Reactive/CouchbaseGetOperationException.cs
+++ b/src/Couchbase.Reactive/CouchbaseGetOperationException.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Reactive
+{
+    /// <summary>
+    /// Exception wrapping an error returned by a Get request via the Reactive engine.
+    /// </summary>
+    class CouchbaseGetOperationException<T> : CouchbaseGetException
+    {
+        private readonly IOperationResult<T> _operationResult;
+
+        /// <summary>
+        /// <see cref="IOperationResult{T}"/> returned by the Couchbase SDK.
+        /// </summary>
+        public IOperationResult<T> OperationResult
+        {
+            get { return _operationResult; }
+        }
+
+        internal CouchbaseGetOperationException(IOperationResult<T> operationResult)
+            : base(operationResult.Status, "Couchbase Get operation returned an error: " + operationResult.Message, operationResult.Exception)
+        {
+            if (operationResult == null)
+            {
+                throw new ArgumentNullException("operationResult");
+            }
+
+            _operationResult = operationResult;
+        }
+    }
+}

--- a/src/Couchbase.Reactive/CouchbaseN1QlQueryException.cs
+++ b/src/Couchbase.Reactive/CouchbaseN1QlQueryException.cs
@@ -8,26 +8,24 @@ using Couchbase.N1QL;
 
 namespace Couchbase.Reactive
 {
-    public class CouchbaseN1QlQueryException : ApplicationException
+    /// <summary>
+    /// Base class for exceptions wrapping errors returned by N1QL query requests via the Reactive engine.
+    /// </summary>
+    public abstract class CouchbaseN1QlQueryException : CouchbaseReactiveException
     {
-        private readonly QueryStatus _status;
-        public QueryStatus Status
-        {
-            get { return _status; }
-        }
+        /// <summary>
+        /// Gets the status of the request.
+        /// </summary>
+        public abstract QueryStatus Status { get; }
 
-        private readonly IList<Error> _errors;
-        public IList<Error> Errors
+        /// <summary>
+        /// Gets a list of zero or more error objects.
+        /// </summary>
+        public abstract IList<Error> Errors { get; }
+
+        internal CouchbaseN1QlQueryException(string message, Exception innerException)
+            : base(message, innerException)
         {
-            get { return _errors; }
-        }
-        internal CouchbaseN1QlQueryException(QueryStatus status, IList<Error> errors)
-            : base(errors != null && errors.Count == 1 ?
-                       errors.First().Message :
-                       "N1QL query error, see Status and Errors properties for details.")
-        {
-            _status = status;
-            _errors = errors;
         }
     }
 }

--- a/src/Couchbase.Reactive/CouchbaseN1QlQueryExceptionT.cs
+++ b/src/Couchbase.Reactive/CouchbaseN1QlQueryExceptionT.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.N1QL;
+
+namespace Couchbase.Reactive
+{
+    /// <summary>
+    /// Exception wrapping an error returned by a N1QL query request via the Reactive engine.
+    /// </summary>
+    public class CouchbaseN1QlQueryException<T> : CouchbaseN1QlQueryException
+    {
+        private readonly IQueryResult<T> _queryResult;
+
+        public IQueryResult<T> QueryResult
+        {
+            get { return _queryResult; }
+        }
+
+        public override QueryStatus Status
+        {
+            get { return _queryResult.Status; }
+        }
+
+        public override IList<Error> Errors
+        {
+            get { return _queryResult.Errors; }
+        }
+
+        internal CouchbaseN1QlQueryException(IQueryResult<T> queryResult)
+            : base(ExtractErrorMessage(queryResult), queryResult.Exception)
+        {
+            if (queryResult == null)
+            {
+                throw new ArgumentNullException("queryResult");
+            }
+
+            _queryResult = queryResult;
+        }
+
+        private static string ExtractErrorMessage(IQueryResult<T> queryResult)
+        {
+            const string messageWrapper = "Couchbase N1QL query returned an error: {0}";
+
+            if (queryResult.Errors != null)
+            {
+                if (queryResult.Errors.Count == 1)
+                {
+                    // Only one error, return that message
+
+                    return string.Format(messageWrapper, queryResult.Errors.First().Message);
+                }
+                else if (queryResult.Errors.Count > 1)
+                {
+                    // More than one error, so return a generic message
+
+                    return string.Format(messageWrapper, "see Errors property for details.");
+                }
+            }
+
+            if (queryResult.Exception != null)
+            {
+                // Use the message from the exception
+
+                return string.Format(messageWrapper, queryResult.Exception.Message);
+            }
+
+            // No error message available
+            return string.Format(messageWrapper, "Unknown error.");
+        }
+    }
+}

--- a/src/Couchbase.Reactive/CouchbaseReactiveException.cs
+++ b/src/Couchbase.Reactive/CouchbaseReactiveException.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Reactive
+{
+    /// <summary>
+    /// Base class for all exceptions related to Rx-Couchbase.
+    /// </summary>
+    public abstract class CouchbaseReactiveException : ApplicationException
+    {
+        internal CouchbaseReactiveException(string message)
+            : base(message)
+        {
+        }
+
+        internal CouchbaseReactiveException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Couchbase.Reactive/CouchbaseViewQueryException.cs
+++ b/src/Couchbase.Reactive/CouchbaseViewQueryException.cs
@@ -7,24 +7,29 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Reactive
 {
-    public class CouchbaseViewQueryException : ApplicationException
+    /// <summary>
+    /// Base class for exceptions wrapping errors returned by view requests via the Reactive engine.
+    /// </summary>
+    public abstract class CouchbaseViewQueryException : CouchbaseReactiveException
     {
-        private readonly HttpStatusCode _statusCode;
-        public HttpStatusCode StatusCode
+        /// <summary>
+        /// The HTTP Status Code for the request.
+        /// </summary>
+        public abstract HttpStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// A View engine specific error message if one occurred.
+        /// </summary>
+        public abstract string Error { get; }
+
+        internal CouchbaseViewQueryException(string message)
+            : base(message)
         {
-            get { return _statusCode; }
         }
 
-        private readonly string _error;
-        public string Error
+        internal CouchbaseViewQueryException(string message, Exception innerException)
+            : base(message, innerException)
         {
-            get { return _error; }
-        }
-        internal CouchbaseViewQueryException(HttpStatusCode statusCode, string error)
-            : base(error)
-        {
-            _statusCode = statusCode;
-            _error = error;
         }
     }
 }

--- a/src/Couchbase.Reactive/CouchbaseViewQueryExceptionT.cs
+++ b/src/Couchbase.Reactive/CouchbaseViewQueryExceptionT.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Views;
+
+namespace Couchbase.Reactive
+{
+    /// <summary>
+    /// Exception wrapping an error returned by a view request via the Reactive engine.
+    /// </summary>
+    public class CouchbaseViewQueryException<T> : CouchbaseViewQueryException
+    {
+        private readonly IViewResult<T> _viewResult;
+
+        /// <summary>
+        /// Result of the view request.
+        /// </summary>
+        public IViewResult<T> ViewResult
+        {
+            get { return _viewResult; }
+        }
+
+        public override HttpStatusCode StatusCode
+        {
+            get { return _viewResult.StatusCode; }
+        }
+
+        public override string Error
+        {
+            get { return _viewResult.Error; }
+        }
+
+        internal CouchbaseViewQueryException(IViewResult<T> viewResult)
+            : base("Couchbase view query returned an error: " + (viewResult.Error ?? "Unknown"),
+                  viewResult.Exception)
+        {
+            if (viewResult == null)
+            {
+                throw new ArgumentNullException("viewResult");
+            }
+
+            _viewResult = viewResult;
+        }
+    }
+}

--- a/src/Couchbase.Reactive/ViewQueryObservable.cs
+++ b/src/Couchbase.Reactive/ViewQueryObservable.cs
@@ -33,58 +33,55 @@ namespace Couchbase.Reactive
         {
             var disposed = false;
 
-            var task = _bucket.QueryAsync<T>(_query);
-
-            // Pass exceptions to the observer as an error
-            task.ContinueWith(t =>
+            try
             {
-                if (!disposed)
-                {
-                    observer.OnError((Exception) t.Exception ?? new InvalidOperationException("Unknown Error"));
-                }
-            }, TaskContinuationOptions.OnlyOnFaulted);
+                var task = _bucket.QueryAsync<T>(_query);
 
-            // Pass canceled tasks as completion to the observer
-            task.ContinueWith(t =>
-            {
-                if (!disposed)
+                // Pass exceptions to the observer as an error
+                task.ContinueWith(t =>
                 {
-                    observer.OnCompleted();
-                }
-            }, TaskContinuationOptions.OnlyOnCanceled);
-
-            // Handle successful task completion
-            task.ContinueWith(t =>
-            {
-                if (!disposed)
-                {
-                    if (t.Result.Success)
+                    if (!disposed)
                     {
-                        // On success, deliver all rows to the observer
+                        observer.OnError((Exception) t.Exception ?? new InvalidOperationException("Unknown Error"));
+                    }
+                }, TaskContinuationOptions.OnlyOnFaulted);
 
-                        foreach (var row in t.Result.Rows)
-                        {
-                            observer.OnNext(row);
-                        }
-
+                // Pass canceled tasks as completion to the observer
+                task.ContinueWith(t =>
+                {
+                    if (!disposed)
+                    {
                         observer.OnCompleted();
                     }
-                    else
+                }, TaskContinuationOptions.OnlyOnCanceled);
+
+                // Handle successful task completion
+                task.ContinueWith(t =>
+                {
+                    if (!disposed)
                     {
-                        // On view error, deliver as an error to the observer
-                        if (t.Result.Exception != null)
+                        if (t.Result.Success)
                         {
-                            observer.OnError(t.Result.Exception);
+                            // On success, deliver all rows to the observer
+
+                            foreach (var row in t.Result.Rows)
+                            {
+                                observer.OnNext(row);
+                            }
+
+                            observer.OnCompleted();
                         }
                         else
                         {
-                            var ex = new CouchbaseViewQueryException(t.Result.StatusCode, t.Result.Error);
-
-                            observer.OnError(ex);
+                            observer.OnError(new CouchbaseViewQueryException<T>(t.Result));
                         }
                     }
-                }
-            }, TaskContinuationOptions.OnlyOnRanToCompletion);
+                }, TaskContinuationOptions.OnlyOnRanToCompletion);
+            }
+            catch (Exception ex)
+            {
+                observer.OnError(ex);
+            }
 
             return Disposable.Create(() => disposed = true);
         }

--- a/src/Rx-Couchbase.sln
+++ b/src/Rx-Couchbase.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Couchbase.Reactive", "Couchbase.Reactive\Couchbase.Reactive.csproj", "{132AF7CC-9157-4D38-A7B6-9F49A67903FB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Couchbase.Reactive.IntegrationTests", "Couchbase.Reactive.IntegrationTests\Couchbase.Reactive.IntegrationTests.csproj", "{963F4A95-B954-4D2A-8BB7-AEB718B58505}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Couchbase.Reactive.UnitTests", "Couchbase.Reactive.UnitTests\Couchbase.Reactive.UnitTests.csproj", "{A7337740-FC0C-4B70-B27E-C3407E8B017A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{963F4A95-B954-4D2A-8BB7-AEB718B58505}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{963F4A95-B954-4D2A-8BB7-AEB718B58505}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{963F4A95-B954-4D2A-8BB7-AEB718B58505}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7337740-FC0C-4B70-B27E-C3407E8B017A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7337740-FC0C-4B70-B27E-C3407E8B017A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7337740-FC0C-4B70-B27E-C3407E8B017A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7337740-FC0C-4B70-B27E-C3407E8B017A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Motivation

Error handling approach is inconsistent between different types of
operations.  Also, exceptions returned in OnError could include more
useful details.
## Modifications

Created abstract base CouchbaseReactiveException for all exceptions which
wrap error results from the SDK.

Modified get operations to return CouchbaseGetException via OnError when
the SDK returns an error for one of the Get operations.  So that we can
return the actual Couchbase result object in the exception, inherited
child exceptions CouchbaseGetOperationException<T> and
CouchbaseGetDocumentException<T> from CouchbaseGetException.

This is more consistent with the Reactive approach, and also allows us to
return results without the additional IOperationResult<T> or
IDocumentResult<T> wrapper.  So plain Get operations return an observable
of KeyValuePair<string, T> and GetDocument operations return an observable
of Document<T>.  This is easier for consumers to use.

In order to address missing keys, which normally return an error from
Couchbase, these keys are simply skipped in the resulting Observable.
This includes the single key get operations, which will return an empty
observable if the key doesn't exist.  This makes all Get operations
consistent in their behavior.

For View and N1QL queries, changed to using an exception with a generic
type parameter so that the exception may contain the IQueryResult<T> or
IViewResult<T> result as a property.  To make catching these exceptions in
bulk easier, inherited each of these from a base exception class without
the generic type parameter.  Also improved their error message logic, and
ensured that any returned Exception property is included as the
InnerException of the wrapper exception.

Both View and N1QL queries were not handling early exceptions, such as
ObjectDisposedException, in a reactive manner.  These are now returned via
OnError.

Cleaned up and improved integration tests.  Created unit tests for various
error handling scenarios, in a new unit test library.
## Results

Error handling is now consistent across various bucket extension methods,
with a more Reactive approach.  Use of exception base classes will make
handling exceptions easier for consumers.  Get operations are also easier
to consume and more logical in their results.
